### PR TITLE
Fix indexing bug in createSTANCEobject

### DIFF
--- a/R/createSTANCEobject.R
+++ b/R/createSTANCEobject.R
@@ -52,7 +52,7 @@ creatSTANCEobject <- function(counts, pos, prop, covariates = NULL){
   spots <- intersect(intersect(barcodes, rownames(pos)), rownames(prop))
   pos.use <- pos[match(spots, rownames(pos)),]
   prop.use <- prop[match(spots, rownames(prop)),]
-  counts.use <- counts[match(spots, colnames(counts)),]
+  counts.use <- counts[,match(spots, colnames(counts))]
   if(!is.null(covariates)){
     covariates.use <- covariates[,match(spots, rownames(covariates))]
   }else{


### PR DESCRIPTION
Fixes a bug in createSTANCEobject where counts was indexed by rows instead of columns. This caused errors when subsetting spots. Now corrected.